### PR TITLE
Fix ItemBlock asm

### DIFF
--- a/src/main/java/net/malisis/core/util/replacement/ReplacementTool.java
+++ b/src/main/java/net/malisis/core/util/replacement/ReplacementTool.java
@@ -113,6 +113,7 @@ public class ReplacementTool {
      * @param replacement the replacement
      * @param vanilla the vanilla
      */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     private void replaceVanilla(int id, String name, String srgFieldName, Object replacement, Object vanilla) {
         boolean block = replacement instanceof Block;
         RegistryNamespaced registry = block ? Block.blockRegistry : Item.itemRegistry;
@@ -126,7 +127,7 @@ public class ReplacementTool {
             f.set(null, replacement);
 
             if (ib != null)
-                AsmUtils.changeFieldAccess(ItemBlock.class, "blockInstance", "field_150939_a")
+                AsmUtils.changeFieldAccess(ItemBlock.class, "field_150939_a", "field_150939_a")
                         .set(ib, replacement);
 
             map.put(replacement, vanilla);

--- a/src/main/java/net/malisis/core/util/replacement/ReplacementTool.java
+++ b/src/main/java/net/malisis/core/util/replacement/ReplacementTool.java
@@ -113,7 +113,7 @@ public class ReplacementTool {
      * @param replacement the replacement
      * @param vanilla the vanilla
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @SuppressWarnings({"rawtypes", "unchecked"})
     private void replaceVanilla(int id, String name, String srgFieldName, Object replacement, Object vanilla) {
         boolean block = replacement instanceof Block;
         RegistryNamespaced registry = block ? Block.blockRegistry : Item.itemRegistry;


### PR DESCRIPTION
This *should* makes MalisisCore usable in dev (the mappings changed while updating the buildscript, in the ones we use, it has no MCP name).