### PR TITLE
Optimize rendering

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1675110695
+//version: 1676679815
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -9,11 +9,15 @@
 import com.diffplug.blowdryer.Blowdryer
 import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.gtnewhorizons.retrofuturagradle.ObfuscationAttribute
 import com.gtnewhorizons.retrofuturagradle.mcp.ReobfuscatedJar
+import com.gtnewhorizons.retrofuturagradle.minecraft.RunMinecraftTask
 import com.matthewprenger.cursegradle.CurseArtifact
 import com.matthewprenger.cursegradle.CurseRelation
 import com.modrinth.minotaur.dependencies.ModDependency
 import com.modrinth.minotaur.dependencies.VersionDependency
+import cpw.mods.fml.relauncher.Side
+import org.gradle.api.tasks.options.Option;
 import org.gradle.internal.logging.text.StyledTextOutput.Style
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.jetbrains.gradle.ext.*
@@ -23,6 +27,7 @@ import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
+import javax.inject.Inject
 
 buildscript {
     repositories {
@@ -66,7 +71,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.7.2' apply false
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.1.2'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.1.6'
 }
 boolean settingsupdated = verifySettingsGradle()
 settingsupdated = verifyGitAttributes() || settingsupdated
@@ -186,11 +191,21 @@ configurations {
 }
 
 if (enableModernJavaSyntax.toBoolean()) {
+    repositories {
+        mavenCentral {
+            mavenContent {
+                includeGroup("me.eigenraven.java8unsupported")
+            }
+        }
+    }
+
     dependencies {
         annotationProcessor 'com.github.bsideup.jabel:jabel-javac-plugin:1.0.0'
         compileOnly('com.github.bsideup.jabel:jabel-javac-plugin:1.0.0') {
             transitive = false // We only care about the 1 annotation class
         }
+        // Allow using jdk.unsupported classes like sun.misc.Unsafe in the compiled code, working around JDK-8206937.
+        patchedMinecraft('me.eigenraven.java8unsupported:java-8-unsupported-shim:1.0.0')
     }
 
     tasks.withType(JavaCompile).configureEach {
@@ -401,6 +416,16 @@ configurations.configureEach {
             }
         }
     }
+    def obfuscationAttr = it.attributes.getAttribute(ObfuscationAttribute.OBFUSCATION_ATTRIBUTE)
+    if (obfuscationAttr != null && obfuscationAttr.name == ObfuscationAttribute.SRG) {
+        resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+            // Remap CoFH core cursemaven dev jar to the obfuscated version for runObfClient/Server
+            if (details.requested.group == 'curse.maven' && details.requested.name.endsWith('-69162') && details.requested.version == '2388751') {
+                details.useVersion '2388750'
+                details.because 'Pick obfuscated jar'
+            }
+        }
+    }
 }
 
 // Ensure tests have access to minecraft classes
@@ -520,20 +545,20 @@ dependencies {
         annotationProcessor('org.ow2.asm:asm-debug-all:5.0.3')
         annotationProcessor('com.google.guava:guava:24.1.1-jre')
         annotationProcessor('com.google.code.gson:gson:2.8.6')
-        annotationProcessor('com.gtnewhorizon:gtnhmixins:2.1.10:processor')
+        annotationProcessor('com.gtnewhorizon:gtnhmixins:2.1.12:processor')
         if (usesMixinDebug.toBoolean()) {
             runtimeOnlyNonPublishable('org.jetbrains:intellij-fernflower:1.2.1.16')
         }
     }
     if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
-        implementation('com.gtnewhorizon:gtnhmixins:2.1.10')
+        implementation('com.gtnewhorizon:gtnhmixins:2.1.12')
     }
 }
 
 pluginManager.withPlugin('org.jetbrains.kotlin.kapt') {
     if (usesMixins.toBoolean()) {
         dependencies {
-            kapt('com.gtnewhorizon:gtnhmixins:2.1.10:processor')
+            kapt('com.gtnewhorizon:gtnhmixins:2.1.12:processor')
         }
     }
 }
@@ -633,7 +658,140 @@ tasks.named("processResources", ProcessResources).configure {
 
     if (usesMixins.toBoolean()) {
         from refMap
+        dependsOn("compileJava", "compileScala")
     }
+}
+
+ext.java17Toolchain = (JavaToolchainSpec spec) -> {
+    spec.languageVersion.set(JavaLanguageVersion.of(17))
+    spec.vendor.set(JvmVendorSpec.matching("jetbrains"))
+}
+
+ext.java17DependenciesCfg = configurations.create("java17Dependencies")
+ext.java17PatchDependenciesCfg = configurations.create("java17PatchDependencies")
+
+dependencies {
+    def lwjgl3ifyVersion = '1.1.21'
+    def asmVersion = '9.4'
+    if (modId != 'lwjgl3ify') {
+        java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
+    }
+    if (modId != 'hodgepodge') {
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.0.35')
+    }
+
+    java17PatchDependencies('net.minecraft:launchwrapper:1.15') {transitive = false}
+    java17PatchDependencies("org.ow2.asm:asm:${asmVersion}")
+    java17PatchDependencies("org.ow2.asm:asm-commons:${asmVersion}")
+    java17PatchDependencies("org.ow2.asm:asm-tree:${asmVersion}")
+    java17PatchDependencies("org.ow2.asm:asm-analysis:${asmVersion}")
+    java17PatchDependencies("org.ow2.asm:asm-util:${asmVersion}")
+    java17PatchDependencies('org.ow2.asm:asm-deprecated:7.1')
+    java17PatchDependencies("org.apache.commons:commons-lang3:3.12.0")
+    java17PatchDependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}:forgePatches")
+}
+
+ext.java17JvmArgs = [
+    // Java 9+ support
+    "--illegal-access=warn",
+    "-Dfile.encoding=UTF-8",
+    "-Djava.security.manager=allow",
+    "--add-opens", "java.base/jdk.internal.loader=ALL-UNNAMED",
+    "--add-opens", "java.base/java.net=ALL-UNNAMED",
+    "--add-opens", "java.base/java.nio=ALL-UNNAMED",
+    "--add-opens", "java.base/java.io=ALL-UNNAMED",
+    "--add-opens", "java.base/java.lang=ALL-UNNAMED",
+    "--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED",
+    "--add-opens", "java.base/java.text=ALL-UNNAMED",
+    "--add-opens", "java.base/java.util=ALL-UNNAMED",
+    "--add-opens", "java.base/jdk.internal.reflect=ALL-UNNAMED",
+    "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED",
+    "--add-opens", "java.desktop/sun.awt.image=ALL-UNNAMED",
+    "--add-modules", "jdk.dynalink",
+    "--add-opens", "jdk.dynalink/jdk.dynalink.beans=ALL-UNNAMED",
+    "--add-modules", "java.sql.rowset",
+    "--add-opens", "java.sql.rowset/javax.sql.rowset.serial=ALL-UNNAMED"
+]
+
+ext.hotswapJvmArgs = [
+    // DCEVM advanced hot reload
+    "-XX:+AllowEnhancedClassRedefinition",
+    "-XX:HotswapAgent=fatjar"
+]
+
+ext.setupHotswapAgentTask = tasks.register("setupHotswapAgent") {
+    group = "GTNH Buildscript"
+    description = "Installs a recent version of HotSwapAgent into the Java 17 JetBrains runtime directory"
+    def hsaUrl = 'https://github.com/HotswapProjects/HotswapAgent/releases/download/1.4.2-SNAPSHOT/hotswap-agent-1.4.2-SNAPSHOT.jar'
+    def targetFolderProvider = javaToolchains.launcherFor(java17Toolchain).map {it.metadata.installationPath.dir("lib/hotswap")}
+    def targetFilename = "hotswap-agent.jar"
+    onlyIf {
+        !targetFolderProvider.get().file(targetFilename).asFile.exists()
+    }
+    doLast {
+        def targetFolder = targetFolderProvider.get()
+        targetFolder.asFile.mkdirs()
+        download.run {
+            src hsaUrl
+            dest targetFolder.file(targetFilename).asFile
+            overwrite false
+            tempAndMove true
+        }
+    }
+}
+
+public abstract class RunHotswappableMinecraftTask extends RunMinecraftTask {
+    // IntelliJ doesn't seem to allow commandline arguments so we also support an env variable
+    private boolean enableHotswap = Boolean.valueOf(System.getenv("HOTSWAP"));
+
+    @Input
+    public boolean getEnableHotswap() { return enableHotswap }
+    @Option(option = "hotswap", description = "Enables HotSwapAgent for enhanced class reloading under a debugger")
+    public boolean setEnableHotswap(boolean enable) { enableHotswap = enable }
+
+    @Inject
+    public RunHotswappableMinecraftTask(Side side, String superTask) {
+        super(side)
+
+        this.lwjglVersion = 3
+        this.javaLauncher = project.javaToolchains.launcherFor(project.java17Toolchain)
+        this.extraJvmArgs.addAll(project.java17JvmArgs)
+        this.extraJvmArgs.addAll(project.provider(() -> enableHotswap ? project.hotswapJvmArgs : []))
+
+        this.classpath(project.java17PatchDependenciesCfg)
+        if (side == Side.CLIENT) {
+            this.classpath(project.minecraftTasks.lwjgl3Configuration)
+        }
+        // Use a raw provider instead of map to not create a dependency on the task
+        this.classpath(project.provider(() -> project.tasks.named(superTask, RunMinecraftTask).get().classpath))
+        this.classpath.filter { file ->
+            !file.path.contains("2.9.4-nightly-20150209") // Remove lwjgl2
+        }
+        this.classpath(project.java17DependenciesCfg)
+
+        if (!(project.usesMixins.toBoolean() || project.forceEnableMixins.toBoolean())) {
+            this.extraArgs.addAll("--tweakClass", "org.spongepowered.asm.launch.MixinTweaker")
+        }
+    }
+}
+
+def runClient17Task = tasks.register("runClient17", RunHotswappableMinecraftTask, Side.CLIENT, "runClient")
+runClient17Task.configure {
+    setup(project)
+    group = "Modded Minecraft"
+    description = "Runs the modded client using Java 17, lwjgl3ify and Hodgepodge"
+    dependsOn(setupHotswapAgentTask, mcpTasks.launcherSources.classesTaskName, minecraftTasks.taskDownloadVanillaAssets, mcpTasks.taskPackagePatchedMc, 'jar')
+    mainClass = "GradleStart"
+}
+
+def runServer17Task = tasks.register("runServer17", RunHotswappableMinecraftTask, Side.SERVER, "runServer")
+runServer17Task.configure {
+    setup(project)
+    group = "Modded Minecraft"
+    description = "Runs the modded server using Java 17, lwjgl3ify and Hodgepodge"
+    dependsOn(setupHotswapAgentTask, mcpTasks.launcherSources.classesTaskName, minecraftTasks.taskDownloadVanillaAssets, mcpTasks.taskPackagePatchedMc, 'jar')
+    mainClass = "GradleStartServer"
+    extraArgs.add("nogui")
 }
 
 def getManifestAttributes() {
@@ -705,7 +863,7 @@ if (usesShadowedDependencies.toBoolean()) {
     javaComponent.withVariantsFromConfiguration(configurations.shadowRuntimeElements) {
         skip()
     }
-    for (runTask in ["runClient", "runServer"]) {
+    for (runTask in ["runClient", "runServer", "runClient17", "runServer17"]) {
         tasks.named(runTask).configure {
             dependsOn("shadowJar")
         }
@@ -743,6 +901,7 @@ idea {
     module {
         downloadJavadoc = true
         downloadSources = true
+        inheritOutputDirs = true
     }
     project {
         settings {
@@ -752,6 +911,20 @@ idea {
                 }
                 "2. Run Server"(Gradle) {
                     taskNames = ["runServer"]
+                }
+                "1a. Run Client (Java 17)"(Gradle) {
+                    taskNames = ["runClient17"]
+                }
+                "2a. Run Server (Java 17)"(Gradle) {
+                    taskNames = ["runServer17"]
+                }
+                "1b. Run Client (Java 17, Hotswap)"(Gradle) {
+                    taskNames = ["runClient17"]
+                    envs = ["HOTSWAP": "true"]
+                }
+                "2b. Run Server (Java 17, Hotswap)"(Gradle) {
+                    taskNames = ["runServer17"]
+                    envs = ["HOTSWAP": "true"]
                 }
                 "3. Run Obfuscated Client"(Gradle) {
                     taskNames = ["runObfClient"]

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 // Add your dependencies here
 
 dependencies {
-    implementation('com.github.GTNewHorizons:GTNHLib:0.0.10:dev')
+    implementation('com.github.GTNewHorizons:GTNHLib:0.0.12:dev')
 }

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -1,9 +1,4 @@
 // Add any additional repositories for your dependencies here
 
 repositories {
-    maven {
-        name "GTNH Maven"
-        url "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
-        allowInsecureProtocol true
-    }
 }

--- a/src/main/java/net/malisis/core/renderer/Parameter.java
+++ b/src/main/java/net/malisis/core/renderer/Parameter.java
@@ -104,6 +104,16 @@ public class Parameter<T> {
         if (parameter.getValue() != null) value = parameter.getValue();
     }
 
+    public T merged(Parameter<T> other) {
+        if (other.value != null) {
+            return other.value;
+        } else if (value != null) {
+            return value;
+        } else {
+            return defaultValue;
+        }
+    }
+
     @Override
     public String toString() {
         return value + " [" + defaultValue + "]";

--- a/src/main/java/net/malisis/core/renderer/RenderParameters.java
+++ b/src/main/java/net/malisis/core/renderer/RenderParameters.java
@@ -13,9 +13,6 @@
 
 package net.malisis.core.renderer;
 
-import java.util.LinkedList;
-import java.util.List;
-
 import net.malisis.core.renderer.animation.transformation.ITransformable;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.IIcon;
@@ -25,9 +22,10 @@ import net.minecraftforge.common.util.ForgeDirection;
  * @author Ordinastie
  *
  */
+@SuppressWarnings("rawtypes")
 public class RenderParameters implements ITransformable.Color, ITransformable.Alpha, ITransformable.Brightness {
 
-    protected List<Parameter> listParams = new LinkedList<>();
+    protected Parameter[] listParams;
     /**
      * Defines whether to render all faces even if shoudSideBeRendered is false
      */
@@ -149,32 +147,11 @@ public class RenderParameters implements ITransformable.Color, ITransformable.Al
     public Parameter<Boolean> flipV = new Parameter<>(false);
 
     public RenderParameters() {
-        listParams.add(renderAllFaces);
-        listParams.add(useBlockBounds);
-        listParams.add(renderBounds);
-        listParams.add(vertexPositionRelativeToRenderBounds);
-        listParams.add(useCustomTexture);
-        listParams.add(applyTexture);
-        listParams.add(icon);
-        listParams.add(useWorldSensitiveIcon);
-        listParams.add(useTexture);
-        listParams.add(interpolateUV);
-        listParams.add(calculateAOColor);
-        listParams.add(calculateBrightness);
-        listParams.add(usePerVertexColor);
-        listParams.add(usePerVertexAlpha);
-        listParams.add(usePerVertexBrightness);
-        listParams.add(useEnvironmentBrightness);
-        listParams.add(useNormals);
-        listParams.add(colorMultiplier);
-        listParams.add(colorFactor);
-        listParams.add(brightness);
-        listParams.add(alpha);
-        listParams.add(direction);
-        listParams.add(textureSide);
-        listParams.add(aoMatrix);
-        listParams.add(flipU);
-        listParams.add(flipV);
+        listParams = new Parameter<?>[] { renderAllFaces, useBlockBounds, renderBounds,
+                vertexPositionRelativeToRenderBounds, useCustomTexture, applyTexture, icon, useWorldSensitiveIcon,
+                useTexture, interpolateUV, calculateAOColor, calculateBrightness, usePerVertexColor, usePerVertexAlpha,
+                usePerVertexBrightness, useEnvironmentBrightness, useNormals, colorMultiplier, colorFactor, brightness,
+                alpha, direction, textureSide, aoMatrix, flipU, flipV, };
     }
 
     public RenderParameters(RenderParameters params) {
@@ -182,19 +159,23 @@ public class RenderParameters implements ITransformable.Color, ITransformable.Al
         merge(params);
     }
 
-    private Parameter getParameter(int index) {
-        if (index < 0 || index >= listParams.size()) return null;
-        return listParams.get(index);
+    private Parameter<?> getParameter(int index) {
+        if (index < 0 || index >= listParams.length) return null;
+        return listParams[index];
     }
 
     public void reset() {
-        for (Parameter param : listParams) param.reset();
+        for (Parameter param : listParams) {
+            param.reset();
+        }
     }
 
     public void merge(RenderParameters params) {
         if (params == null) return;
 
-        for (int i = 0; i < listParams.size(); i++) getParameter(i).merge(params.getParameter(i));
+        for (int i = 0; i < listParams.length; i++) {
+            listParams[i].merge(params.listParams[i]);
+        }
     }
 
     @Override


### PR DESCRIPTION
On a superflat world in the malisisdoors environement with ~100 doors with these changes I go from 100 to 220 FPS, and allocation rate reduces from ~1.2GB/s to 800MB/s. Any more changes would require more significant refactoring of the code, but this should make door rendering less of a bottleneck.

I change a protected field type from a List to an array, but it looks like none of the malisis mods use it or even subclass RenderParameters, so it shouldn't cause ABI breaks.